### PR TITLE
Feature/button component styles

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -16,8 +16,9 @@
 <style>
 	:root{
 		--grey-100: #000000;
-		--grey-750: #EFEFEF;
-		--grey-800: #F5F5F5;
+		--grey-700: #dddddd;
+		--grey-750: #efefef;
+		--grey-800: #f5f5f5;
 		--grey-850: #f1f1f1;
 		--grey-900: #ffffff;
 

--- a/app/components/AppButton.vue
+++ b/app/components/AppButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button @click="onClick" :class='color'>
+	<button @click="onClick" :class='getClass()'>
 		<slot></slot>
 	</button>
 </template>
@@ -32,6 +32,10 @@
 			background: var(--blue-500);
 		}
 	}
+
+	button.full-width {
+		width: 100%;
+	}
 </style>
 
 <script>
@@ -39,12 +43,22 @@
 		methods: {
 			onClick() {
 				this.$emit('click');
+			},
+			getClass() {
+				return {
+					[this.color]: true,
+					'full-width': this.fullWidth
+				}
 			}
 		},
 		props: {
 			color: {
 				type: String,
 				default: 'default'
+			},
+			fullWidth: {
+				type: Boolean,
+				default: false
 			}
 		}
 	};

--- a/app/components/AppButton.vue
+++ b/app/components/AppButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button @click="onClick">
+	<button @click="onClick" :class='color'>
 		<slot></slot>
 	</button>
 </template>
@@ -7,16 +7,29 @@
 <style scoped>
 	button {
 		cursor: pointer;
-		color: var(--grey-900);
+		color: var(--grey-100);
+		background: var(--grey-700);
 		font-family: 'Raleway', sans-serif;
-		background: var(--blue-400);
+		font-size: 1.2rem;
 		border: none;
 		border-radius: 5px;
 		padding: 10px 20px;
 		transition: all .4s ease;
 
 		&:hover {
-			background: #42a5f5;
+			background: #cccccc;
+		}
+
+		&:focus {
+			outline: 0;
+		}
+	}
+
+	button.primary {
+		color: var(--grey-900);
+		background: var(--blue-400);
+		&:hover {
+			background: var(--blue-500);
 		}
 	}
 </style>
@@ -26,6 +39,12 @@
 		methods: {
 			onClick() {
 				this.$emit('click');
+			}
+		},
+		props: {
+			color: {
+				type: String,
+				default: 'default'
 			}
 		}
 	};

--- a/app/components/AppButton.vue
+++ b/app/components/AppButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button @click="onClick" :class='getClass()'>
+	<button @click="onClick" :class='getClass()' :disabled='disabled'>
 		<slot></slot>
 	</button>
 </template>
@@ -22,6 +22,10 @@
 
 		&:focus {
 			outline: 0;
+		}
+
+		&:disabled {
+			cursor: not-allowed;
 		}
 	}
 
@@ -57,6 +61,10 @@
 				default: 'default'
 			},
 			fullWidth: {
+				type: Boolean,
+				default: false
+			},
+			disabled: {
 				type: Boolean,
 				default: false
 			}


### PR DESCRIPTION
Added several generic options for the AppButton component
1. color option
The button now supports two colors: `default` and `primary`. The color property is `default` by default
![image](https://user-images.githubusercontent.com/31656049/83648476-0eaad700-a5f1-11ea-9408-77ac8d78da95.png)
![image](https://user-images.githubusercontent.com/31656049/83648535-208c7a00-a5f1-11ea-9338-dda0c6e0c735.png)
2. fullWidth option
Setting the fullWidth option will make the button horizontally fit its container's width. `false` by default
![image](https://user-images.githubusercontent.com/31656049/83648651-40bc3900-a5f1-11ea-8ead-db090ba62359.png)
3. disabled option
Setting the disabled option will make the button disabled. `false` by default
